### PR TITLE
fix: Ubuntu 26.04 base image (drop removed php-imap)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Base image: opinionated Apache httpd on Ubuntu with SSL and common proxy modules.
 # docker build -t wsams/httpd:local --rm --pull .
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 COPY httpd-foreground /usr/bin/
 

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -13,7 +13,6 @@ RUN apt-get update && \
         php-curl \
         php-gd \
         php-imagick \
-        php-imap \
         php-mongodb \
         php-mysql \
         php-sqlite3 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # httpd Docker image
 
-Opinionated Apache httpd 2.4 images on Ubuntu 24.04, published as a single Docker Hub repository with flavor tags.
+Opinionated Apache httpd 2.4 images on Ubuntu 26.04, published as a single Docker Hub repository with flavor tags.
 
 | Tag | Contents |
 | --- | --- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Renovate Ubuntu 26.04 bump failed CI because `php-imap` is no longer available on resolute (IMAP was unbundled from PHP 8.4+ and the Ubuntu package was removed).

**Changes**
- Bump base image `ubuntu:24.04` → `ubuntu:26.04`
- Remove `php-imap` from `Dockerfile.php` (no apt candidate on 26.04; keeping the package line cannot work)
- Update README Ubuntu version mention

This supersedes https://github.com/wsams/httpd/pull/8 — that PR can be closed once this merges.

Failed run: https://github.com/wsams/httpd/actions/runs/29203576480/job/86678953080
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f581c-e057-7293-9d20-95ac6d0e8437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f581c-e057-7293-9d20-95ac6d0e8437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

